### PR TITLE
Delete all local refs and handle exceptions

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -31,15 +31,7 @@ echo "Patching cmake files to work on this machine"
         # these are the include dirs for OpenJDK 8
         sed -i -e '/set.LIBS/i include_directories(/usr/lib/jvm/java-8-openjdk-amd64/include)' CMakeLists.txt
         sed -i -e '/set.LIBS/i include_directories(/usr/lib/jvm/java-8-openjdk-amd64/include/linux)' CMakeLists.txt
-	# Arch Linux
-        sed -i -e '/set.LIBS/i include_directories(/usr/lib/jvm/java-8-openjdk/include)' CMakeLists.txt
-        sed -i -e '/set.LIBS/i include_directories(/usr/lib/jvm/java-8-openjdk/include/linux)' CMakeLists.txt
     fi
-)
-
-echo "Ensuring sources are up to date"
-(
-    cp native/*.cpp ../llvm-project/clang/tools/libclang/
 )
 
 echo "Running cmake"

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -31,7 +31,15 @@ echo "Patching cmake files to work on this machine"
         # these are the include dirs for OpenJDK 8
         sed -i -e '/set.LIBS/i include_directories(/usr/lib/jvm/java-8-openjdk-amd64/include)' CMakeLists.txt
         sed -i -e '/set.LIBS/i include_directories(/usr/lib/jvm/java-8-openjdk-amd64/include/linux)' CMakeLists.txt
+	# Arch Linux
+        sed -i -e '/set.LIBS/i include_directories(/usr/lib/jvm/java-8-openjdk/include)' CMakeLists.txt
+        sed -i -e '/set.LIBS/i include_directories(/usr/lib/jvm/java-8-openjdk/include/linux)' CMakeLists.txt
     fi
+)
+
+echo "Ensuring sources are up to date"
+(
+    cp native/*.cpp ../llvm-project/clang/tools/libclang/
 )
 
 echo "Running cmake"

--- a/native/eu_cqse_clang_ClangBinding.cpp
+++ b/native/eu_cqse_clang_ClangBinding.cpp
@@ -2,9 +2,12 @@
 #include "Index.h"
 #include <cstdlib>
 #include <cstring>
+#include <mutex>
 
 #include "../../../clang/include/clang/Tooling/CompilationDatabase.h"
 #include "../../../clang-tools-extra/clang-tidy/ClangTidy.h"
+
+// general hint: see https://stackoverflow.com/a/6245964 for local references and freeing them
 
 // Parameters with environment info passed into the visit method
 struct ClangBindingVisitorParameter {
@@ -14,65 +17,149 @@ struct ClangBindingVisitorParameter {
 };
 
 
-#define CLANG_JNI_BEGIN_EXCEPTION_HANDLER try {
+#define CLANG_JNI_BEGIN_EXCEPTION_HANDLER try { jni_helper::initializeJniClasses()
+
 #define CLANG_JNI_END_EXCEPTION_HANDLER(NAME) \
   } catch (const std::exception &e) { \
-    jclass exceptionClass = env->FindClass("java/lang/RuntimeException"); \
     std::string message = "Exception in clang-tidy integration method " NAME ": "; \
     message += e.what(); \
-    env->ThrowNew (exceptionClass, message.c_str()); \
+    env->ThrowNew (jni_helper::runtimeExceptionClass, message.c_str()); \
     return 0; \
   } catch (...) { \
-    jclass exceptionClass = env->FindClass("java/lang/RuntimeException"); \
-    env->ThrowNew (exceptionClass, "Unknown low level exception in clang-tidy integration method " NAME "!"); \
+    env->ThrowNew (jni_helper::runtimeExceptionClass, "Unknown low level exception in clang-tidy integration method " NAME "!"); \
     return 0; \
   }
 #define CLANG_JNI_END_EXCEPTION_HANDLER_NO_RETURN(NAME) \
   } catch (const std::exception &e) { \
-    jclass exceptionClass = env->FindClass("java/lang/RuntimeException"); \
     std::string message = "Exception in clang-tidy integration method " NAME ": "; \
     message += e.what(); \
-    env->ThrowNew (exceptionClass, message.c_str()); \
+    env->ThrowNew (jni_helper::runtimeExceptionClass, message.c_str()); \
     return; \
   } catch (...) { \
-    jclass exceptionClass = env->FindClass("java/lang/RuntimeException"); \
-    env->ThrowNew (exceptionClass, "Unknown low level exception in clang-tidy integration method " NAME "!"); \
+    env->ThrowNew (jni_helper::runtimeExceptionClass, "Unknown low level exception in clang-tidy integration method " NAME "!"); \
     return; \
   }
 
 namespace jni_helper{
 
-  std::string obtainString (JNIEnv *env, jstring s) {
-      const char *temp = env->GetStringUTFChars(s, 0);
-      std::string result (temp);
-      env->ReleaseStringUTFChars(s, temp);
-      return result;
-  }
+    mutex initializationMutex;
+    bool isInitialized = false;
 
-  void handlePossibleJniException(JNIEnv *env) {
-      jthrowable exc = env->ExceptionOccurred();
-      if (exc) {
-          env->ExceptionDescribe();
-          env->ExceptionClear();
+    // classes and methods that we use/need all over the place
+    jclass runtimeExceptionClass;
+    jmethodID runtimeExceptionConstructor
 
-          /* We don't do much with the exception, except that we print a
-             debug message using ExceptionDescribe, clear it, and throw
-             a new exception. */
-          jclass newExcCls = env->FindClass("java/lang/IllegalArgumentException");
-          if (newExcCls == 0) {
-              // Unable to find the new exception class, give up.
-              return;
-          }
-          env->ThrowNew(newExcCls, "Caught illegal argument exception when calling java code.");
-          env->DeleteLocalRef(newExcCls);
-      }
-  }
+    jclass clangSpellingLocationPropertiesClass;
+    jmethodID clangSpellingLocationPropertiesConstructor;
+
+    jclass arrayListClass;
+    jmethodID arrayListConstructor;
+    jmethodID arrayListAdd;
+
+    jclass hashMapClass;
+    jmethodID hashMapConstructor;
+    jmethodID hashMapPut;
+
+    jclass listClass;
+    jmethodID listAdd;
+    jmethodID listSize;
+    jmethodID listGet;
+
+    jclass clangTidyFileClass;
+    jmethodID clangTidyFileGetPath;
+    jmethodID clangTidyFileGetContent;
+
+    jclass clangTidyErrorClass;
+    jmethodID clangTidyErrorConstructor;
+    
+    void initializeJniClasses (JNIEnv *env) {
+        if (isInitialized) {
+            return;
+        }
+
+        // following region is under lock until the lock is released,
+        // which automatically happens at method exit
+        std::unique_lock<mutex> lock(initializationMutex);
+        
+        if (isInitialized) {
+            return;
+        }
+
+        runtimeExceptionClass = env->FindClass("java/lang/RuntimeException");
+        HANDLE_JNI_NULL_RESULT(runtimeExceptionClass);
+        runtimeExceptionConstructor = env->GetMethodID(runtimeExceptionClass, "<init>", "(Ljava/lang/Throwable;)V");
+        HANDLE_JNI_NULL_RESULT(runtimeExceptionConstructor);
+
+        clangSpellingLocationPropertiesClass = env->FindClass("eu/cqse/clang/ClangSpellingLocationProperties");
+        HANDLE_JNI_NULL_RESULT(clangSpellingLocationPropertiesClass);
+        clangSpellingLocationPropertiesConstructor =
+            env->GetMethodID(clangSpellingLocationPropertiesClass, "<init>", "(Ljava/lang/String;III)V");
+        HANDLE_JNI_NULL_RESULT(clangSpellingLocationPropertiesConstructor);
+
+        arrayListClass = env->FindClass("java/util/ArrayList");
+        HANDLE_JNI_NULL_RESULT(arrayListClass);
+        arrayListConstructor = env->GetMethodID(arrayListClass, "<init>", "()V");
+        HANDLE_JNI_NULL_RESULT(arrayListConstructor);
+        arrayListAdd = env->GetMethodID(arrayListClass, "add", "(Ljava/lang/Object;)Z");
+        HANDLE_JNI_NULL_RESULT(arrayListAdd);
+
+        hashMapClass = env->FindClass("java/util/HashMap");
+        HANDLE_JNI_NULL_RESULT(hashMapClass);
+        hashMapConstructor = env->GetMethodID(hashMapClass, "<init>", "()V");
+        HANDLE_JNI_NULL_RESULT(hashMapConstructor);
+        hashMapPut = env->GetMethodID(hashMapClass, "put",
+				     "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+        HANDLE_JNI_NULL_RESULT(hashMapPut);
+
+        listClass = env->FindClass("java/util/List");
+        HANDLE_JNI_NULL_RESULT(listClass);
+        listAdd = env->GetMethodID(listClass, "add", "(Ljava/lang/Object;)Z");
+        HANDLE_JNI_NULL_RESULT(listAdd);
+        listSize = env->GetMethodID(listClass, "size", "()I");
+        HANDLE_JNI_NULL_RESULT(listSize);
+        listGet = env->GetMethodID(listClass, "get", "(I)Ljava/lang/Object;");
+        HANDLE_JNI_NULL_RESULT(listGet);
+
+        clangTidyFileClass = env->FindClass("eu/cqse/clang/ClangTidyFile");
+        HANDLE_JNI_NULL_RESULT(clangTidyFileClass);
+        clangTidyFileGetPath = env->GetMethodID(clangTidyFileClass, "getPath", "()Ljava/lang/String;");
+        HANDLE_JNI_NULL_RESULT(clangTidyFileGetPath);
+        clangTidyFileGetContent = env->GetMethodID(clangTidyFileClass, "getContent", "()Ljava/lang/String;");
+        HANDLE_JNI_NULL_RESULT(clangTidyFileGetContent);
+
+        clangTidyErrorClass = env->FindClass("eu/cqse/clang/ClangTidyError");
+        HANDLE_JNI_NULL_RESULT(clangTidyErrorClass);
+        clangTidyErrorConstructor = env->GetMethodID
+            (clangTidyErrorClass, "<init>", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V");
+        HANDLE_JNI_NULL_RESULT(clangTidyErrorConstructor);
+    
+        isInitialized = true;
+    }
+    
+    void handlePossibleJniException(JNIEnv *env) {
+        jthrowable exc = env->ExceptionOccurred();
+        if (exc) {
+            env->ExceptionClear();
+            env->Throw(env->NewObject (runtimeExceptionClass, runtimeExceptionConstructor, exc));
+        }
+    }
+
+#define HANDLE_JNI_NULL_RESULT(X) if(!X) handlePossibleJniException(env)    
+    
+    std::string obtainString (JNIEnv *env, jstring s) {
+        const char *temp = env->GetStringUTFChars(s, 0);
+        HANDLE_JNI_NULL_RESULT(temp);
+        std::string result (temp);
+        env->ReleaseStringUTFChars(s, temp);
+        return result;
+    }
+
 }
 
 JNIEXPORT void JNICALL Java_eu_cqse_clang_ClangBinding_visitChildrenImpl
   (JNIEnv * env, jclass cls, jlong cursor_pointer, jobject java_visitor) {
 
-    CLANG_JNI_BEGIN_EXCEPTION_HANDLER  
+    CLANG_JNI_BEGIN_EXCEPTION_HANDLER;
   
     CXCursor root_cursor = **(CXCursor **)&cursor_pointer;
     
@@ -85,14 +172,14 @@ JNIEXPORT void JNICALL Java_eu_cqse_clang_ClangBinding_visitChildrenImpl
                         [](CXCursor cursor, CXCursor parent, CXClientData client_data) {
                             jlong cursor_copy = 0;
                             {
-				CXCursor * cursorptr = (CXCursor *) malloc(sizeof(CXCursor));
+				CXCursor * cursorptr = new CXCursor();
 				memmove(cursorptr, &cursor, sizeof(CXCursor));
 				*(CXCursor **)&cursor_copy = cursorptr;
                             }
                             
                             jlong parent_copy = 0;
                             {
-				CXCursor * parentptr = (CXCursor *) malloc(sizeof(CXCursor));
+				CXCursor * parentptr = new CXCursor();
 				memmove(parentptr, &parent, sizeof(CXCursor));
 				*(CXCursor **)&parent_copy = parentptr;
                             }
@@ -100,6 +187,7 @@ JNIEXPORT void JNICALL Java_eu_cqse_clang_ClangBinding_visitChildrenImpl
                             ClangBindingVisitorParameter* param = (ClangBindingVisitorParameter*)client_data;
                             jint result = param->env->CallIntMethod(param->java_visitor, param->method, cursor_copy, parent_copy);
                             jni_helper::handlePossibleJniException(param->env);
+
                             return (CXChildVisitResult) result;
                         }, &parameter);
 
@@ -109,7 +197,7 @@ JNIEXPORT void JNICALL Java_eu_cqse_clang_ClangBinding_visitChildrenImpl
 JNIEXPORT jobject JNICALL Java_eu_cqse_clang_ClangBinding_getSpellingLocationPropertiesImpl
   (JNIEnv *env, jclass cls, jlong location_ptr) {
 
-    CLANG_JNI_BEGIN_EXCEPTION_HANDLER  
+    CLANG_JNI_BEGIN_EXCEPTION_HANDLER;
 
     CXSourceLocation location = **(CXSourceLocation **)&location_ptr;
 
@@ -117,15 +205,15 @@ JNIEXPORT jobject JNICALL Java_eu_cqse_clang_ClangBinding_getSpellingLocationPro
     unsigned line, column, offset;
     clang_getSpellingLocation(location, &file, &line, &column, &offset);
     
-    jclass result_class = env->FindClass("eu/cqse/clang/ClangSpellingLocationProperties");
-    jmethodID constructor = env->GetMethodID(result_class, "<init>", "(Ljava/lang/String;III)V");
-
     CXString fileName = clang_getFileName (file);
     jstring javaFileName = env->NewStringUTF(clang_getCString(fileName));
+    HANDLE_JNI_NULL_RESULT(javaFileName);
     clang_disposeString (fileName);
 
-    jobject result = env->NewObject (result_class, constructor, javaFileName, line, column, offset);
-    env->DeleteLocalRef(result_class);
+    jobject result = env->NewObject (jni_helper::clangSpellingLocationPropertiesClass,
+                                     jni_helper::clangSpellingLocationPropertiesConstructor,
+                                     javaFileName, line, column, offset);
+    HANDLE_JNI_NULL_RESULT(result);
     return result;
     CLANG_JNI_END_EXCEPTION_HANDLER("getSpellingLocationPropertiesImpl")
 }
@@ -133,7 +221,7 @@ JNIEXPORT jobject JNICALL Java_eu_cqse_clang_ClangBinding_getSpellingLocationPro
 JNIEXPORT jobject JNICALL Java_eu_cqse_clang_ClangBinding_getExpansionLocationPropertiesImpl
   (JNIEnv *env, jclass cls, jlong location_ptr) {
 
-    CLANG_JNI_BEGIN_EXCEPTION_HANDLER  
+    CLANG_JNI_BEGIN_EXCEPTION_HANDLER;
 
     CXSourceLocation location = **(CXSourceLocation **)&location_ptr;
 
@@ -141,16 +229,15 @@ JNIEXPORT jobject JNICALL Java_eu_cqse_clang_ClangBinding_getExpansionLocationPr
     unsigned line, column, offset;
     clang_getExpansionLocation(location, &file, &line, &column, &offset);
     
-    jclass result_class = env->FindClass("eu/cqse/clang/ClangSpellingLocationProperties");
-    jmethodID constructor = env->GetMethodID(result_class, "<init>", "(Ljava/lang/String;III)V");
-
     CXString fileName = clang_getFileName (file);
     jstring javaFileName = env->NewStringUTF(clang_getCString(fileName));
+    HANDLE_JNI_NULL_RESULT(javaFileName);
     clang_disposeString (fileName);
 
-    jobject result = env->NewObject (result_class, constructor, javaFileName, line, column, offset);
-
-    env->DeleteLocalRef(result_class);
+    jobject result = env->NewObject (jni_helper::clangSpellingLocationPropertiesClass,
+                                     jni_helper::clangSpellingLocationPropertiesConstructor,
+                                     javaFileName, line, column, offset);
+    HANDLE_JNI_NULL_RESULT(result);
     return result;
     CLANG_JNI_END_EXCEPTION_HANDLER("getExpansionLocationPropertiesImpl")
 }
@@ -158,25 +245,22 @@ JNIEXPORT jobject JNICALL Java_eu_cqse_clang_ClangBinding_getExpansionLocationPr
 JNIEXPORT jobject JNICALL Java_eu_cqse_clang_ClangBinding_getAllClangTidyChecks
   (JNIEnv *env, jclass cls) {
 
-    CLANG_JNI_BEGIN_EXCEPTION_HANDLER  
+    CLANG_JNI_BEGIN_EXCEPTION_HANDLER;
 
-    jclass arrayListClass = env->FindClass("java/util/ArrayList");
-    jmethodID constructor = env->GetMethodID(arrayListClass, "<init>", "()V");
-    jobject result = env->NewObject (arrayListClass, constructor);
+    jobject result = env->NewObject (jni_helper::arrayListClass, jni_helper::arrayListConstructor);
+    HANDLE_JNI_NULL_RESULT(result);
 
     clang::tidy::ClangTidyOptions options = clang::tidy::ClangTidyOptions::getDefaults();
     options.Checks = "*";
     std::vector<std::string> checkNames = clang::tidy::getCheckNames(options, true);
 
-    jmethodID add = env->GetMethodID(arrayListClass, "add", "(Ljava/lang/Object;)Z");
     for (std::vector<std::string>::iterator i = checkNames.begin(), end = checkNames.end(); i != end; ++i) {
       jstring nameString = env->NewStringUTF (i->c_str());
-      env->CallObjectMethod (result, add, nameString);
+      HANDLE_JNI_NULL_RESULT(nameString);
+      env->CallObjectMethod (result, jni_helper::arrayListAdd, nameString);
       jni_helper::handlePossibleJniException(env);
       env->DeleteLocalRef(nameString);
     }
-
-    env->DeleteLocalRef(arrayListClass);
     return result;
 
     CLANG_JNI_END_EXCEPTION_HANDLER("getAllClangTidyChecks")
@@ -185,63 +269,42 @@ JNIEXPORT jobject JNICALL Java_eu_cqse_clang_ClangBinding_getAllClangTidyChecks
 JNIEXPORT jobject JNICALL Java_eu_cqse_clang_ClangBinding_getAllClangTidyCheckOptions
   (JNIEnv *env, jclass cls) {
 
-    CLANG_JNI_BEGIN_EXCEPTION_HANDLER  
+    CLANG_JNI_BEGIN_EXCEPTION_HANDLER;
 
-    jclass hashMapClass = env->FindClass("java/util/HashMap");
-    jmethodID constructor = env->GetMethodID(hashMapClass, "<init>", "()V");
-    jobject result = env->NewObject (hashMapClass, constructor);
+    jobject result = env->NewObject (jni_helper::hashMapClass, jni_helper::hashMapConstructor);
+    HANDLE_JNI_NULL_RESULT(result);
 
     clang::tidy::ClangTidyOptions options = clang::tidy::ClangTidyOptions::getDefaults();
     options.Checks = "*";
     clang::tidy::ClangTidyOptions::OptionMap checkOptions = clang::tidy::getCheckOptions(options, true);
 
-    jmethodID put = env->GetMethodID(hashMapClass, "put",
-				     "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
     for (clang::tidy::ClangTidyOptions::OptionMap::iterator i = checkOptions.begin(),
-	   end = checkOptions.end(); i != end; ++i) {
-	   jstring key = env->NewStringUTF (i->first.c_str());
-	   jstring value = env->NewStringUTF (i->second.c_str());
-      env->CallObjectMethod (result, put, key, value);
-	  jni_helper::handlePossibleJniException(env);
-	  env->DeleteLocalRef(key);
-	  env->DeleteLocalRef(value);
-      }
+             end = checkOptions.end(); i != end; ++i) {
+        jstring key = env->NewStringUTF (i->first.c_str());
+        HANDLE_JNI_NULL_RESULT(key);
+        jstring value = env->NewStringUTF (i->second.c_str());
+        HANDLE_JNI_NULL_RESULT(value);
+        
+        env->CallObjectMethod (result, jni_helper::hashMapPut, key, value);
+        jni_helper::handlePossibleJniException(env);
+        
+        env->DeleteLocalRef(key);
+        env->DeleteLocalRef(value);
+    }
 
-    env->DeleteLocalRef(hashMapClass);
     return result;
 
     CLANG_JNI_END_EXCEPTION_HANDLER("getAllClangTidyCheckOptions")
 }
 
-
-
-
 JNIEXPORT jobject JNICALL Java_eu_cqse_clang_ClangBinding_runClangTidyInternal
 (JNIEnv *env, jclass cls, jobject files, jstring rules, jobject compilerSwitches,
  jobject checkOptionsKeys, jobject checkOptionsValues, jboolean codeIsCpp) {
 
-    CLANG_JNI_BEGIN_EXCEPTION_HANDLER
-    
-    jclass listClass = env->FindClass("java/util/List");
-    jmethodID add = env->GetMethodID(listClass, "add", "(Ljava/lang/Object;)Z");
-    jmethodID size = env->GetMethodID(listClass, "size", "()I");
-    jmethodID get = env->GetMethodID(listClass, "get", "(I)Ljava/lang/Object;");
-    env->DeleteLocalRef(listClass);
-
-    jclass arrayListClass = env->FindClass("java/util/ArrayList");
-    jmethodID constructor = env->GetMethodID(arrayListClass, "<init>", "()V");
-
-    jclass fileClass = env->FindClass("eu/cqse/clang/ClangTidyFile");
-    jmethodID fileGetPath = env->GetMethodID(fileClass, "getPath", "()Ljava/lang/String;");
-    jmethodID fileGetContent = env->GetMethodID(fileClass, "getContent", "()Ljava/lang/String;");
-    env->DeleteLocalRef(fileClass);
-
-    jclass errorClass = env->FindClass("eu/cqse/clang/ClangTidyError");
-    jmethodID errorConstructor = env->GetMethodID
-      (errorClass, "<init>", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V");
-
-    jobject result = env->NewObject (arrayListClass, constructor);
-    env->DeleteLocalRef(arrayListClass);
+    CLANG_JNI_BEGIN_EXCEPTION_HANDLER;
+        
+    jobject result = env->NewObject (jni_helper::arrayListClass, jni_helper::arrayListConstructor);
+    HANDLE_JNI_NULL_RESULT(result);
 
     clang::tidy::ClangTidyGlobalOptions globalOptions;
     clang::tidy::ClangTidyOptions options = clang::tidy::ClangTidyOptions::getDefaults();
@@ -255,19 +318,21 @@ JNIEXPORT jobject JNICALL Java_eu_cqse_clang_ClangBinding_runClangTidyInternal
     }
 
     // check options; we assume both options to have same size
-    int checkOptionsSize = env->CallIntMethod (checkOptionsKeys, size);
+    int checkOptionsSize = env->CallIntMethod (checkOptionsKeys, jni_helper::listSize);
     jni_helper::handlePossibleJniException(env);
 
     for (int i = 0; i < checkOptionsSize; ++i) {
-      jobject keyObject = env->CallObjectMethod (checkOptionsKeys, get, i);
-      jni_helper::handlePossibleJniException(env);
-      jobject valueObject = env->CallObjectMethod (checkOptionsValues, get, i);
-      jni_helper::handlePossibleJniException(env);
+      jobject keyObject = env->CallObjectMethod (checkOptionsKeys, jni_helper::listGet, i);
+      HANDLE_JNI_NULL_RESULT(keyObject);
+
+      jobject valueObject = env->CallObjectMethod (checkOptionsValues, jni_helper::listGet, i);
+      HANDLE_JNI_NULL_RESULT(valueObject);
 
       options.CheckOptions.insert ({ jni_helper::obtainString(env, (jstring)keyObject),
-	    jni_helper::obtainString(env, (jstring)valueObject)});
-	  env->DeleteLocalRef(keyObject);
-	  env->DeleteLocalRef(valueObject);
+                  jni_helper::obtainString(env, (jstring)valueObject)});
+      
+      env->DeleteLocalRef(keyObject);
+      env->DeleteLocalRef(valueObject);
     }
     
     auto optionsProvider = llvm::make_unique<clang::tidy::DefaultOptionsProvider>(globalOptions, options);
@@ -277,14 +342,15 @@ JNIEXPORT jobject JNICALL Java_eu_cqse_clang_ClangBinding_runClangTidyInternal
     std::vector<std::string> argvBuffer;
     argv.push_back("my-compiler");
     argv.push_back("--");
-    int compilerSwitchesSize = env->CallIntMethod (compilerSwitches, size);
+    int compilerSwitchesSize = env->CallIntMethod (compilerSwitches, jni_helper::listSize);
     jni_helper::handlePossibleJniException(env);
+    
     for (int i = 0; i < compilerSwitchesSize; ++i) {
-      jobject compilerSwitch = env->CallObjectMethod (compilerSwitches, get, i);
-      jni_helper::handlePossibleJniException(env);
-      argvBuffer.push_back(jni_helper::obtainString(env, (jstring)compilerSwitch));
-      argv.push_back (argvBuffer.back().c_str());
-      env->DeleteLocalRef(compilerSwitch);
+        jobject compilerSwitch = env->CallObjectMethod (compilerSwitches, jni_helper::listGet, i);
+        HANDLE_JNI_NULL_RESULT(compilerSwitch);
+        argvBuffer.push_back(jni_helper::obtainString(env, (jstring)compilerSwitch));
+        argv.push_back (argvBuffer.back().c_str());
+        env->DeleteLocalRef(compilerSwitch);
     }
     argv.push_back(0);
     int argc = argv.size()-1;
@@ -297,50 +363,61 @@ JNIEXPORT jobject JNICALL Java_eu_cqse_clang_ClangBinding_runClangTidyInternal
     llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> inMemoryFS(new llvm::vfs::InMemoryFileSystem());
     time_t modificationTime = std::time(0);
     
-    int filesSize = env->CallIntMethod (files, size);
+    int filesSize = env->CallIntMethod (files, jni_helper::listSize);
     jni_helper::handlePossibleJniException(env);
+    
     for (int i = 0; i < filesSize; ++i) {
-      jobject file = env->CallObjectMethod (files, get, i);
-      jni_helper::handlePossibleJniException(env);
-      jobject path = env->CallObjectMethod (file, fileGetPath);
-      jni_helper::handlePossibleJniException(env);
-      jobject content = env->CallObjectMethod (file, fileGetContent);
-      jni_helper::handlePossibleJniException(env);
+        jobject file = env->CallObjectMethod (files, jni_helper::listGet, i);
+        HANDLE_JNI_NULL_RESULT(file);
+      
+        jobject path = env->CallObjectMethod (file, jni_helper::clangTidyFileGetPath);
+        HANDLE_JNI_NULL_RESULT(path);
+        
+        jobject content = env->CallObjectMethod (file, jni_helper::clangTidyFileGetContent);
+        HANDLE_JNI_NULL_RESULT(content);
+        
+        // we use vectors to simplify memory management and scoping
+        inputFiles.push_back (jni_helper::obtainString(env, (jstring)path));
+        contents.push_back (jni_helper::obtainString(env, (jstring)content));
+        
+        auto buffer = llvm::MemoryBuffer::getMemBuffer(contents.back().c_str());
+        inMemoryFS->addFile(inputFiles.back(), modificationTime, std::move(buffer));
 
-      // we use vectors to simplify memory management and scoping
-      inputFiles.push_back (jni_helper::obtainString(env, (jstring)path));
-      contents.push_back (jni_helper::obtainString(env, (jstring)content));
-
-      auto buffer = llvm::MemoryBuffer::getMemBuffer(contents.back().c_str());
-      inMemoryFS->addFile(inputFiles.back(), modificationTime, std::move(buffer));
-
-      env->DeleteLocalRef(file);
-      env->DeleteLocalRef(path);
-      env->DeleteLocalRef(content);
+        env->DeleteLocalRef(path);
+        env->DeleteLocalRef(content);
+        env->DeleteLocalRef(file);
     }
 
     llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> overlayFS
-      (new llvm::vfs::OverlayFileSystem(llvm::vfs::getRealFileSystem()));
+        (new llvm::vfs::OverlayFileSystem(llvm::vfs::getRealFileSystem()));
     overlayFS->pushOverlay(inMemoryFS);
     
     std::vector<clang::tidy::ClangTidyError> errors =
-      runClangTidy(context, *compilations, inputFiles, overlayFS);
+        runClangTidy(context, *compilations, inputFiles, overlayFS);
     
     for (std::vector<clang::tidy::ClangTidyError>::iterator i = errors.begin(), end = errors.end(); i != end; ++i) {
-      jstring diagnosticName = env->NewStringUTF(i->DiagnosticName.c_str());
-      jstring message = env->NewStringUTF(i->Message.Message.c_str());
-      jstring filePath =  env->NewStringUTF(i->Message.FilePath.c_str());
-      jobject javaError = env->NewObject (errorClass, errorConstructor, diagnosticName, message, filePath,
-                                          i->Message.FileOffset);
-      env->CallObjectMethod (result, add, javaError);
-      jni_helper::handlePossibleJniException(env);
-      env->DeleteLocalRef(diagnosticName);
-      env->DeleteLocalRef(message);
-      env->DeleteLocalRef(filePath);
-      env->DeleteLocalRef(javaError);
+        jstring diagnosticName = env->NewStringUTF(i->DiagnosticName.c_str());
+        HANDLE_JNI_NULL_RESULT(diagnosticName);
+        
+        jstring message = env->NewStringUTF(i->Message.Message.c_str());
+        HANDLE_JNI_NULL_RESULT(message);
+        
+        jstring filePath =  env->NewStringUTF(i->Message.FilePath.c_str());
+        HANDLE_JNI_NULL_RESULT(filePath);
+
+        jobject javaError = env->NewObject (jni_helper::clangTidyErrorClass, jni_helper::clangTidyErrorConstructor,
+                                            diagnosticName, message, filePath, i->Message.FileOffset);
+        HANDLE_JNI_NULL_RESULT(javaError);
+        
+        env->CallObjectMethod (result, jni_helper::listAdd, javaError);
+        jni_helper::handlePossibleJniException(env);
+        
+        env->DeleteLocalRef(javaError);
+        env->DeleteLocalRef(diagnosticName);
+        env->DeleteLocalRef(message);
+        env->DeleteLocalRef(filePath);
     }
 
-    env->DeleteLocalRef(errorClass);
     return result;
 
     CLANG_JNI_END_EXCEPTION_HANDLER("runClangTidyInternal")

--- a/src/eu/cqse/clang/ClangBinding.java
+++ b/src/eu/cqse/clang/ClangBinding.java
@@ -46,7 +46,7 @@ public class ClangBinding {
 		 * {@link CXCursor}.
 		 */
 		public int visit(long cursorPtr, long parentPtr) {
-			return delegate.visit(new CXCursor(cursorPtr, false), new CXCursor(parentPtr, false)).swigValue();
+			return delegate.visit(new CXCursor(cursorPtr, true), new CXCursor(parentPtr, true)).swigValue();
 		}
 	}
 


### PR DESCRIPTION
We need to make sure to remove all local refs, as to avoid overflow in
the ref counter. Additionally, we need to be careful to check for
possible exceptions after every single call to java, from c++.